### PR TITLE
show error message on empty forgot password form submission

### DIFF
--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -131,7 +131,7 @@ export function LoginForm({
                       <span>Password</span>
                       <a
                         href="/forget-password"
-                        className="ml-auto inline-block text-sm underline-offset-4 hover:underline"
+                        className="ml-auto inline-block text-sm underline-offset-4 hover:underline text-foreground"
                       >
                         Forgot your password?
                       </a>


### PR DESCRIPTION
### Summary
![Screenshot 2025-05-02 230750](https://github.com/user-attachments/assets/4cf4b750-ee49-46fc-99d1-df226f33d42b)

This PR fixes an issue where the "Forgot Password" text appeared red even before the user submitted the form. The red error styling now only appears after an invalid (empty) submission attempt, improving user experience and visual clarity.

### Changes Made
- Adjusted validation logic to only apply red styling after form submission.